### PR TITLE
feat: Implement 3-stage pipeline architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,24 +4,111 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a DVD auto-ripper utility for Linux servers. It automatically detects DVD insertion via udev, rips the disc using HandBrake, and transfers the output to a NAS.
+This is a DVD auto-ripper utility for Linux servers. It automatically detects DVD insertion via udev, creates an ISO backup using ddrescue, encodes to video using HandBrake, and transfers the output to a NAS/Plex server.
 
-## Architecture
+## Architecture: 3-Stage Pipeline
 
-- **scripts/dvd-utils.sh**: Bash library with helper functions (logging, state management, DVD operations, NAS transfer)
-- **scripts/dvd-ripper.sh**: Main orchestration script that handles the complete workflow
-- **config/dvd-ripper.conf.example**: Configuration template (deployed to /etc/dvd-ripper.conf)
+The system uses a decoupled pipeline architecture for reliability and efficiency:
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│   Stage 1: ISO  │     │ Stage 2: Encode │     │ Stage 3: NAS    │
+│   (udev trigger)│────▶│ (15 min timer)  │────▶│ (15 min timer)  │
+│                 │     │                 │     │                 │
+│ dvd-iso.sh      │     │ dvd-encoder.sh  │     │ dvd-transfer.sh │
+│ - ddrescue ISO  │     │ - HandBrake     │     │ - rsync to NAS  │
+│ - Eject disc    │     │ - Mark ISO done │     │ - Cleanup local │
+└─────────────────┘     └─────────────────┘     └─────────────────┘
+        │                       │                       │
+        ▼                       ▼                       ▼
+  .iso-ready-*           .encoded-ready-*         [Complete]
+  (state file)            (state file)
+```
+
+### Benefits of Pipeline Mode
+- **Drive freed immediately** - disc ejected after ISO creation (~30 min vs 2-4 hours)
+- **Resumable** - ddrescue can resume interrupted ISO creation
+- **Decoupled** - encoding/transfer failures don't affect disc operations
+- **Queue-based** - multiple ISOs can queue up for encoding
+
+### Scripts
+
+| Script | Trigger | Purpose |
+|--------|---------|---------|
+| `dvd-iso.sh` | udev (disc insert) | Create ISO from DVD, eject immediately |
+| `dvd-encoder.sh` | systemd timer (15 min) | Encode ONE queued ISO to MKV |
+| `dvd-transfer.sh` | systemd timer (15 min) | Transfer ONE encoded video to NAS |
+| `dvd-ripper.sh` | manual | Legacy monolithic mode (all-in-one) |
+| `dvd-utils.sh` | sourced | Shared library functions |
+
+### State Files
+
+State files in `/var/tmp/dvd-rips/` track pipeline progress:
+
+| State File | Meaning |
+|------------|---------|
+| `.iso-creating-TITLE-TS` | ISO creation in progress |
+| `.iso-ready-TITLE-TS` | ISO complete, waiting for encoder |
+| `.encoding-TITLE-TS` | HandBrake encoding in progress |
+| `.encoded-ready-TITLE-TS` | Video ready for NAS transfer |
+| `.transferring-TITLE-TS` | NAS transfer in progress |
+| `*.iso.deletable` | ISO marked for cleanup after encode |
+
+### Lock Files
+
+| Lock File | Purpose |
+|-----------|---------|
+| `/var/run/dvd-ripper-iso.lock` | Stage 1: Only one ISO creation |
+| `/var/run/dvd-ripper-encoder.lock` | Stage 2: Only one encode |
+| `/var/run/dvd-ripper-transfer.lock` | Stage 3: Only one transfer |
+
+### Configuration
+
+Key settings in `/etc/dvd-ripper.conf`:
+- `PIPELINE_MODE="1"` - Enable 3-stage pipeline (default)
+- `NAS_ENABLED="1"` - Enable NAS transfer stage
+- `NAS_HOST`, `NAS_USER`, `NAS_PATH` - NAS connection details
+
+### Other Files
+
+- **config/dvd-ripper.conf.example**: Configuration template
+- **config/99-dvd-ripper.rules**: udev rule for disc detection
+- **config/dvd-encoder.timer**: systemd timer for encoding
+- **config/dvd-transfer.timer**: systemd timer for NAS transfer
 - **deploy.sh**: Deployment script for syncing to remote server
-- **remote-install.sh**: Installation script for remote server (requires sudo)
+- **remote-install.sh**: Installation script for remote server
 
 ## Development Workflow
 
+### Branch Strategy
+
+Use feature branches with naming convention: `<github-username>/<branch-type>/<branch-name>`
+
+```bash
+# Create feature branch
+git checkout -b mschober/feature/my-feature
+
+# Push and create PR
+git push -u origin mschober/feature/my-feature
+gh pr create --title "Feature: Description" --body "Details"
+
+# Merge via PR (squash)
+gh pr merge --squash
+```
+
+Branch types: `feature`, `fix`, `refactor`, `docs`, `test`
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for full guidelines.
+
 ### Making Changes
 
-1. Edit scripts locally
-2. Commit and push to GitHub: `git push origin main`
-3. SSH to server and pull changes: `ssh <user>@<server> 'cd /opt/dvd-auto-ripper && sudo git pull'`
-4. Run install script: `ssh <user>@<server> 'cd /opt/dvd-auto-ripper && sudo ./remote-install.sh'`
+1. Create feature branch from `main`
+2. Make changes and commit
+3. Push branch and create PR
+4. After merge, deploy to server:
+   ```bash
+   ssh <user>@<server> 'cd /opt/dvd-auto-ripper && sudo git pull && sudo ./remote-install.sh'
+   ```
 
 ### Initial Server Setup
 
@@ -43,11 +130,20 @@ sudo ./remote-install.sh --install-libdvdcss
 
 ### Testing
 
-Manual testing:
+Manual testing (pipeline mode):
 ```bash
-# On remote server
-sudo /usr/local/bin/dvd-ripper.sh /dev/sr0
+# On remote server - test each stage
+sudo /usr/local/bin/dvd-iso.sh /dev/sr0      # Stage 1: Create ISO
+sudo systemctl start dvd-encoder.service      # Stage 2: Encode
+sudo systemctl start dvd-transfer.service     # Stage 3: Transfer
+
+# Monitor progress
 tail -f /var/log/dvd-ripper.log
+```
+
+Legacy monolithic mode (if needed):
+```bash
+sudo /usr/local/bin/dvd-ripper.sh /dev/sr0
 ```
 
 ### Deployment
@@ -70,7 +166,42 @@ ssh <user>@<server> 'cd /opt/dvd-auto-ripper && sudo git pull && sudo ./remote-i
 
 ## Common Tasks
 
-- **View logs**: `ssh <user>@<server> 'tail -f /var/log/dvd-ripper.log'`
-- **Check config**: `ssh <user>@<server> 'sudo cat /etc/dvd-ripper.conf'`
-- **Check for running rips**: `ssh <user>@<server> 'cat /var/run/dvd-ripper.pid'`
-- **View staging files**: `ssh <user>@<server> 'ls -lh /var/tmp/dvd-rips/'`
+### Monitoring
+
+```bash
+# View logs
+tail -f /var/log/dvd-ripper.log
+
+# Check timer status
+systemctl list-timers | grep dvd
+
+# Check queue status
+ls -la /var/tmp/dvd-rips/.iso-ready-*      # Pending encodes
+ls -la /var/tmp/dvd-rips/.encoded-ready-*  # Pending transfers
+ls -la /var/tmp/dvd-rips/*.iso.deletable   # ISOs awaiting cleanup
+```
+
+### Manual Triggers
+
+```bash
+# Manually trigger stages
+sudo systemctl start dvd-encoder.service   # Encode now
+sudo systemctl start dvd-transfer.service  # Transfer now
+
+# Test ISO creation with a DVD
+sudo /usr/local/bin/dvd-iso.sh /dev/sr0
+```
+
+### Troubleshooting
+
+```bash
+# Check if locks are held
+ls -la /var/run/dvd-ripper-*.lock
+
+# View systemd journal for specific service
+journalctl -u dvd-encoder.service -f
+journalctl -u dvd-transfer.service -f
+
+# Check config
+sudo cat /etc/dvd-ripper.conf
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,72 @@
+# Contributing Guide
+
+## Branch Strategy
+
+Use the following naming convention for branches:
+
+```
+<github-username>/<branch-type>/<branch-name>
+```
+
+### Branch Types
+
+| Type | Purpose | Example |
+|------|---------|---------|
+| `feature` | New functionality | `mschober/feature/pipeline-architecture` |
+| `fix` | Bug fixes | `mschober/fix/eject-timeout` |
+| `refactor` | Code improvements | `mschober/refactor/state-management` |
+| `docs` | Documentation only | `mschober/docs/api-reference` |
+| `test` | Test additions | `mschober/test/encoder-unit-tests` |
+
+### Workflow
+
+1. Create feature branch from `main`:
+   ```bash
+   git checkout main
+   git pull origin main
+   git checkout -b mschober/feature/my-feature
+   ```
+
+2. Make changes and commit:
+   ```bash
+   git add -A
+   git commit -m "Description of changes"
+   ```
+
+3. Push branch and create PR:
+   ```bash
+   git push -u origin mschober/feature/my-feature
+   gh pr create --title "Feature: My Feature" --body "Description"
+   ```
+
+4. After PR approval, merge to main:
+   ```bash
+   gh pr merge --squash
+   ```
+
+## Commit Message Format
+
+```
+<type>: <short description>
+
+<optional longer description>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
+
+## Development Setup
+
+See [CLAUDE.md](./CLAUDE.md) for:
+- Architecture overview
+- Initial server setup
+- Testing procedures
+- Common tasks
+
+## Code Style
+
+- Bash scripts: Use `set -euo pipefail`
+- Functions: Use lowercase with underscores (`my_function`)
+- Variables: Use UPPERCASE for config, lowercase for local
+- Always quote variables: `"$var"` not `$var`

--- a/WORKLIST.md
+++ b/WORKLIST.md
@@ -1,0 +1,40 @@
+# DVD Auto-Ripper Worklist
+
+Future improvements and backlog items.
+
+## Pending Items
+
+### Plex-Ready Naming Convention
+- **Priority:** High
+- **Description:** Update video naming to use Plex-compatible format
+- **Current:** `The_Matrix-1999-1703615234.mkv`
+- **Desired:** `The Matrix (1999).mkv`
+- **Notes:**
+  - Remove underscores, use spaces
+  - Format: `Title (Year).ext`
+  - Remove timestamp from filename (only needed for dedup during processing)
+  - Consider using TMDb/OMDb API for accurate title/year lookup
+  - Handle TV shows differently: `Show Name - S01E01 - Episode Title.mkv`
+
+### ISO Cleanup Job
+- **Priority:** Medium
+- **Description:** Create monthly cron job to delete `*.iso.deletable` files
+- **Notes:** Files are marked `.deletable` after successful encoding
+
+### Metadata Lookup Integration
+- **Priority:** Low
+- **Description:** Integrate with TMDb or OMDb API for accurate movie metadata
+- **Notes:**
+  - Would improve title accuracy
+  - Could fetch year, genres, etc.
+  - Requires API key configuration
+
+### Web UI for Monitoring
+- **Priority:** Low
+- **Description:** Simple web interface to view queue status and logs
+- **Notes:** Could show pending ISOs, encoding progress, transfer status
+
+### Email/Notification on Completion
+- **Priority:** Low
+- **Description:** Send notification when rip/encode/transfer completes
+- **Notes:** Could integrate with email, Slack, Discord, etc.

--- a/config/99-dvd-ripper.rules
+++ b/config/99-dvd-ripper.rules
@@ -1,7 +1,12 @@
-# Udev rule for automatic DVD ripping
-# Triggers systemd service when DVD media is inserted
+# Udev rule for automatic DVD ripping (Pipeline Mode)
+# Triggers ISO creation when DVD media is inserted
 # Uses systemd-run to escape udev's cgroup/environment restrictions
+#
+# Pipeline Mode (default):
+#   Stage 1: dvd-iso.sh creates ISO, ejects disc immediately
+#   Stage 2: dvd-encoder.sh runs via timer (every 15 min)
+#   Stage 3: dvd-transfer.sh runs via timer (every 15 min)
 #
 # ID_CDROM_MEDIA=1 ensures we only trigger on insert, not eject
 
-KERNEL=="sr[0-9]*", SUBSYSTEM=="block", ENV{ID_CDROM}=="1", ACTION=="change", ENV{ID_CDROM_MEDIA}=="1", RUN+="/usr/bin/systemd-run --no-block /usr/local/bin/dvd-ripper.sh /dev/%k"
+KERNEL=="sr[0-9]*", SUBSYSTEM=="block", ENV{ID_CDROM}=="1", ACTION=="change", ENV{ID_CDROM_MEDIA}=="1", RUN+="/usr/bin/systemd-run --no-block /usr/local/bin/dvd-iso.sh /dev/%k"

--- a/config/dvd-encoder.service
+++ b/config/dvd-encoder.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=DVD Encoder Service (Pipeline Stage 2)
+Documentation=https://github.com/mschober/dvd-auto-ripper
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/dvd-encoder.sh
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=dvd-encoder
+
+# Resource limits - encoding is CPU intensive
+CPUQuota=80%
+MemoryMax=4G
+
+# Long timeout for encoding (4 hours max)
+TimeoutStartSec=4h
+
+# Nice value - lower priority than interactive processes
+Nice=10
+
+[Install]
+WantedBy=multi-user.target

--- a/config/dvd-encoder.timer
+++ b/config/dvd-encoder.timer
@@ -1,0 +1,19 @@
+[Unit]
+Description=DVD Encoder Timer (runs every 15 minutes)
+Documentation=https://github.com/mschober/dvd-auto-ripper
+
+[Timer]
+# Start 5 minutes after boot
+OnBootSec=5min
+
+# Run every 15 minutes
+OnUnitActiveSec=15min
+
+# Add some randomness to avoid thundering herd
+RandomizedDelaySec=30
+
+# Persist timer across reboots
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/config/dvd-ripper.conf.example
+++ b/config/dvd-ripper.conf.example
@@ -130,6 +130,35 @@ RETRY_DELAY="60"
 # NOTIFY_EMAIL_SUBJECT="[DVD Ripper]"
 
 # ============================================================================
+# Pipeline Mode Configuration
+# ============================================================================
+# The 3-stage pipeline separates DVD processing into independent steps:
+#   Stage 1 (udev trigger): Create ISO from DVD, eject immediately
+#   Stage 2 (cron/timer):   Encode ISO to video (15 min intervals)
+#   Stage 3 (cron/timer):   Transfer video to NAS (15 min intervals)
+#
+# Benefits: Drive is freed quickly, encoding happens in background
+
+# Enable pipeline mode (0=monolithic single-process, 1=3-stage pipeline)
+# When enabled, dvd-iso.sh handles disc insertion, dvd-encoder.sh and
+# dvd-transfer.sh run via systemd timers
+PIPELINE_MODE="1"
+
+# Stage-specific lock files (pipeline mode)
+ISO_LOCK_FILE="/var/run/dvd-ripper-iso.lock"
+ENCODER_LOCK_FILE="/var/run/dvd-ripper-encoder.lock"
+TRANSFER_LOCK_FILE="/var/run/dvd-ripper-transfer.lock"
+
+# Cleanup settings (pipeline mode)
+# Delete local MKV after successful NAS transfer
+CLEANUP_MKV_AFTER_TRANSFER="1"
+# Delete ISO after successful NAS transfer (ISO marked .deletable after encode)
+CLEANUP_ISO_AFTER_TRANSFER="1"
+
+# Disk usage threshold (percentage) - skip ripping if disk is too full
+DISK_USAGE_THRESHOLD="80"
+
+# ============================================================================
 # Advanced Options
 # ============================================================================
 

--- a/config/dvd-transfer.service
+++ b/config/dvd-transfer.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=DVD Transfer Service (Pipeline Stage 3)
+Documentation=https://github.com/mschober/dvd-auto-ripper
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/dvd-transfer.sh
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=dvd-transfer
+
+# Reasonable timeout for transfer (1 hour max)
+TimeoutStartSec=1h
+
+# Nice value - lower priority than interactive processes
+Nice=5
+
+[Install]
+WantedBy=multi-user.target

--- a/config/dvd-transfer.timer
+++ b/config/dvd-transfer.timer
@@ -1,0 +1,19 @@
+[Unit]
+Description=DVD Transfer Timer (runs every 15 minutes)
+Documentation=https://github.com/mschober/dvd-auto-ripper
+
+[Timer]
+# Start 7 minutes after boot (staggered from encoder)
+OnBootSec=7min
+
+# Run every 15 minutes
+OnUnitActiveSec=15min
+
+# Add some randomness to avoid thundering herd
+RandomizedDelaySec=30
+
+# Persist timer across reboots
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/dvd-encoder.sh
+++ b/scripts/dvd-encoder.sh
@@ -1,0 +1,256 @@
+#!/bin/bash
+# DVD Encoder - Stage 2 of Pipeline
+# Processes ONE pending ISO per run, encodes to MKV using HandBrake
+# Run via cron/systemd timer every 15 minutes
+
+set -euo pipefail
+
+# Get script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source utility functions
+source "${SCRIPT_DIR}/dvd-utils.sh"
+
+# Configuration (overridden by config file)
+HANDBRAKE_PRESET="${HANDBRAKE_PRESET:-Fast 1080p30}"
+HANDBRAKE_QUALITY="${HANDBRAKE_QUALITY:-20}"
+HANDBRAKE_FORMAT="${HANDBRAKE_FORMAT:-mkv}"
+MIN_FILE_SIZE_MB="${MIN_FILE_SIZE_MB:-100}"
+
+# ============================================================================
+# Encoding Function
+# ============================================================================
+
+encode_iso() {
+    local state_file="$1"
+    local metadata iso_path sanitized_title year timestamp main_title
+    local output_filename output_path state_file_encoding
+
+    log_info "[ENCODER] Processing: $state_file"
+
+    # Read metadata from state file
+    metadata=$(read_pipeline_state "$state_file")
+
+    # Parse metadata
+    sanitized_title=$(parse_json_field "$metadata" "title")
+    year=$(parse_json_field "$metadata" "year")
+    timestamp=$(parse_json_field "$metadata" "timestamp")
+    main_title=$(parse_json_field "$metadata" "main_title")
+    iso_path=$(parse_json_field "$metadata" "iso_path")
+
+    log_info "[ENCODER] Title: '$sanitized_title', Year: '$year', ISO: $iso_path"
+
+    # Verify ISO exists
+    if [[ ! -f "$iso_path" ]]; then
+        log_error "[ENCODER] ISO file not found: $iso_path"
+        log_warn "[ENCODER] Removing orphaned state file"
+        remove_state_file "$state_file"
+        return 1
+    fi
+
+    # Generate output filename
+    output_filename=$(generate_filename "$sanitized_title" "$year" "$HANDBRAKE_FORMAT")
+    output_path="${STAGING_DIR}/${output_filename}"
+
+    # Update metadata with MKV path
+    metadata=$(build_state_metadata "$sanitized_title" "$year" "$timestamp" "$main_title" "$iso_path" "$output_path")
+
+    # Transition state: iso-ready -> encoding
+    remove_state_file "$state_file"
+    state_file_encoding=$(create_pipeline_state "encoding" "$sanitized_title" "$timestamp" "$metadata")
+
+    log_info "[ENCODER] Starting HandBrake encode"
+    log_info "[ENCODER] Input: $iso_path"
+    log_info "[ENCODER] Output: $output_path"
+    log_info "[ENCODER] Preset: $HANDBRAKE_PRESET, Quality: $HANDBRAKE_QUALITY"
+
+    # Build HandBrake command
+    local handbrake_cmd="HandBrakeCLI"
+    handbrake_cmd+=" -i \"$iso_path\""
+    handbrake_cmd+=" -o \"$output_path\""
+    handbrake_cmd+=" --preset \"$HANDBRAKE_PRESET\""
+    handbrake_cmd+=" -q \"$HANDBRAKE_QUALITY\""
+
+    # Add main title selection if available
+    if [[ -n "$main_title" ]]; then
+        handbrake_cmd+=" -t \"$main_title\""
+    fi
+
+    # Add extra options if specified
+    if [[ -n "${HANDBRAKE_EXTRA_OPTS:-}" ]]; then
+        handbrake_cmd+=" $HANDBRAKE_EXTRA_OPTS"
+    fi
+
+    # Execute with retry logic
+    local attempt=1
+    local success=false
+
+    while [[ $attempt -le $MAX_RETRIES ]]; do
+        log_info "[ENCODER] Encode attempt $attempt/$MAX_RETRIES"
+
+        if eval "$handbrake_cmd" >> "$LOG_FILE" 2>&1; then
+            success=true
+            break
+        else
+            log_error "[ENCODER] HandBrake failed on attempt $attempt"
+            attempt=$((attempt + 1))
+
+            if [[ $attempt -le $MAX_RETRIES ]]; then
+                log_warn "[ENCODER] Retrying in ${RETRY_DELAY}s..."
+                sleep "$RETRY_DELAY"
+            fi
+        fi
+    done
+
+    if [[ "$success" != "true" ]]; then
+        log_error "[ENCODER] Encoding failed after $MAX_RETRIES attempts"
+
+        # Cleanup partial output
+        cleanup_files "$output_path"
+
+        # Revert state back to iso-ready for future retry
+        remove_state_file "$state_file_encoding"
+        create_pipeline_state "iso-ready" "$sanitized_title" "$timestamp" "$metadata" > /dev/null
+
+        log_warn "[ENCODER] ISO returned to queue for retry"
+        return 1
+    fi
+
+    # Verify output file size
+    if ! verify_file_size "$output_path" "$MIN_FILE_SIZE_MB"; then
+        log_error "[ENCODER] Output file verification failed"
+
+        # Cleanup and revert
+        cleanup_files "$output_path"
+        remove_state_file "$state_file_encoding"
+        create_pipeline_state "iso-ready" "$sanitized_title" "$timestamp" "$metadata" > /dev/null
+
+        log_warn "[ENCODER] ISO returned to queue for retry"
+        return 1
+    fi
+
+    log_info "[ENCODER] Encoding successful"
+
+    # Mark ISO as deletable (robust - handle missing file gracefully)
+    local iso_deletable="${iso_path}.deletable"
+    if [[ -f "$iso_path" ]]; then
+        if mv "$iso_path" "$iso_deletable" 2>/dev/null; then
+            log_info "[ENCODER] Marked ISO for cleanup: $iso_deletable"
+        else
+            log_warn "[ENCODER] Could not rename ISO to .deletable (may already be renamed)"
+        fi
+        # Also remove mapfile if it exists
+        rm -f "${iso_path}.mapfile" 2>/dev/null
+    else
+        log_warn "[ENCODER] ISO file not found for cleanup (already deleted?): $iso_path"
+    fi
+
+    # Transition state: encoding -> encoded-ready
+    remove_state_file "$state_file_encoding"
+    create_pipeline_state "encoded-ready" "$sanitized_title" "$timestamp" "$metadata" > /dev/null
+
+    local output_size=$(stat -c%s "$output_path" 2>/dev/null || echo "0")
+    local output_size_mb=$((output_size / 1024 / 1024))
+    log_info "[ENCODER] Encode complete: ${output_size_mb}MB"
+
+    return 0
+}
+
+# ============================================================================
+# Recovery Function
+# ============================================================================
+
+check_encoder_recovery() {
+    log_info "[ENCODER] Checking for interrupted encoding operations..."
+
+    # Check for interrupted encodes
+    local interrupted=$(find_state_files "encoding")
+    if [[ -n "$interrupted" ]]; then
+        log_warn "[ENCODER] Found interrupted encoding"
+        while IFS= read -r state_file; do
+            log_info "[ENCODER] Checking interrupted encode: $state_file"
+
+            # Read metadata
+            local metadata=$(read_pipeline_state "$state_file")
+            local mkv_path=$(parse_json_field "$metadata" "mkv_path")
+            local sanitized_title=$(parse_json_field "$metadata" "title")
+            local timestamp=$(parse_json_field "$metadata" "timestamp")
+
+            # Check if MKV exists and is valid size
+            if [[ -f "$mkv_path" ]] && verify_file_size "$mkv_path" "$MIN_FILE_SIZE_MB" 2>/dev/null; then
+                log_info "[ENCODER] Found valid MKV from interrupted encode, transitioning to encoded-ready"
+                remove_state_file "$state_file"
+                create_pipeline_state "encoded-ready" "$sanitized_title" "$timestamp" "$metadata" > /dev/null
+            else
+                log_info "[ENCODER] MKV invalid or missing, returning ISO to queue"
+                # Clean up partial MKV
+                [[ -f "$mkv_path" ]] && rm -f "$mkv_path"
+                # Revert to iso-ready
+                remove_state_file "$state_file"
+                create_pipeline_state "iso-ready" "$sanitized_title" "$timestamp" "$metadata" > /dev/null
+            fi
+        done <<< "$interrupted"
+    fi
+}
+
+# ============================================================================
+# Main Entry Point
+# ============================================================================
+
+main() {
+    # Initialize
+    init_logging || exit 1
+    ensure_staging_dir
+
+    log_info "[ENCODER] ==================== DVD Encoder Started ===================="
+
+    # Try to acquire stage lock (non-blocking)
+    if ! acquire_stage_lock "encoder"; then
+        log_info "[ENCODER] Another encoder is already running, exiting"
+        exit 0
+    fi
+
+    # Set up cleanup trap
+    trap 'release_stage_lock "encoder"; log_info "[ENCODER] DVD Encoder stopped"' EXIT INT TERM
+
+    # Check for recovery scenarios
+    check_encoder_recovery
+
+    # Find oldest iso-ready state file
+    local state_file=$(find_oldest_state "iso-ready")
+
+    if [[ -z "$state_file" ]]; then
+        log_info "[ENCODER] No ISOs pending encoding"
+        exit 0
+    fi
+
+    local pending=$(count_pending_state "iso-ready")
+    log_info "[ENCODER] Found $pending ISO(s) pending encoding"
+    log_info "[ENCODER] Processing oldest: $state_file"
+
+    # Check disk space before encoding
+    if ! check_disk_space "$STAGING_DIR"; then
+        log_error "[ENCODER] Insufficient disk space, skipping encode"
+        exit 1
+    fi
+
+    # Encode the ISO
+    encode_iso "$state_file"
+    local exit_code=$?
+
+    if [[ $exit_code -eq 0 ]]; then
+        log_info "[ENCODER] Encoding completed successfully"
+        local remaining=$(count_pending_state "iso-ready")
+        local pending_transfer=$(count_pending_state "encoded-ready")
+        log_info "[ENCODER] ISOs remaining: $remaining, Videos pending transfer: $pending_transfer"
+    else
+        log_error "[ENCODER] Encoding failed"
+    fi
+
+    exit $exit_code
+}
+
+# Run main function if script is executed directly
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/scripts/dvd-iso.sh
+++ b/scripts/dvd-iso.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+# DVD ISO Creator - Stage 1 of Pipeline
+# Creates ISO from DVD using ddrescue, then ejects disc immediately
+# Encoding happens later via dvd-encoder.sh (cron job)
+
+set -euo pipefail
+
+# Get script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source utility functions
+source "${SCRIPT_DIR}/dvd-utils.sh"
+
+# Configuration (overridden by config file)
+DVD_DEVICE="${DVD_DEVICE:-/dev/sr0}"
+
+# ============================================================================
+# ISO Creation Function
+# ============================================================================
+
+create_dvd_iso() {
+    local device="$1"
+    local dvd_info title year main_title duration
+    local iso_path state_file_creating state_file_ready
+
+    log_info "[ISO] Starting ISO creation for device: $device"
+
+    # Extract DVD information
+    dvd_info=$(get_dvd_info "$device")
+    if [[ $? -ne 0 ]]; then
+        log_error "[ISO] Failed to extract DVD information"
+        return 1
+    fi
+
+    # Parse DVD info (format: title|year|main_title|duration)
+    IFS='|' read -r title year main_title duration <<< "$dvd_info"
+
+    log_info "[ISO] DVD Info - Title: '$title', Year: '$year', Main Title: $main_title, Duration: $duration"
+
+    # Check for duplicates (check NAS if configured)
+    if check_duplicate "$title" "$year"; then
+        log_warn "[ISO] Duplicate detected, aborting ISO creation"
+        eject_disc "$device"
+        return 2
+    fi
+
+    # Set umask so output files are world-readable
+    umask 022
+
+    # Generate paths
+    local timestamp=$(date +%s)
+    local sanitized_title=$(sanitize_filename "$title")
+    iso_path="${STAGING_DIR}/${sanitized_title}-${timestamp}.iso"
+
+    # Build metadata for state file
+    local metadata=$(build_state_metadata "$sanitized_title" "$year" "$timestamp" "$main_title" "$iso_path")
+
+    # Create "creating" state file (for crash recovery)
+    state_file_creating=$(create_pipeline_state "iso-creating" "$sanitized_title" "$timestamp" "$metadata")
+
+    log_info "[ISO] Creating ISO: $iso_path"
+
+    # Create the ISO
+    if create_iso "$device" "$iso_path"; then
+        log_info "[ISO] ISO created successfully: $iso_path"
+
+        # Verify ISO size
+        local iso_size=$(stat -c%s "$iso_path" 2>/dev/null || echo "0")
+        local iso_size_mb=$((iso_size / 1024 / 1024))
+        log_info "[ISO] ISO size: ${iso_size_mb}MB"
+
+        # Transition state: creating -> ready
+        remove_state_file "$state_file_creating"
+        state_file_ready=$(create_pipeline_state "iso-ready" "$sanitized_title" "$timestamp" "$metadata")
+
+        log_info "[ISO] ISO ready for encoding: $state_file_ready"
+
+        # Eject disc immediately - drive is now free for next disc
+        eject_disc "$device"
+
+        log_info "[ISO] Disc ejected, ISO creation complete"
+        return 0
+    else
+        log_error "[ISO] ISO creation failed"
+
+        # Cleanup
+        cleanup_files "$iso_path" "${iso_path}.mapfile"
+        remove_state_file "$state_file_creating"
+
+        eject_disc "$device"
+        return 1
+    fi
+}
+
+# ============================================================================
+# Recovery Function
+# ============================================================================
+
+check_iso_recovery() {
+    log_info "[ISO] Checking for interrupted ISO operations..."
+
+    # Check for interrupted ISO creations
+    local interrupted=$(find_state_files "iso-creating")
+    if [[ -n "$interrupted" ]]; then
+        log_warn "[ISO] Found interrupted ISO creation"
+        while IFS= read -r state_file; do
+            log_info "[ISO] Cleaning up interrupted ISO: $state_file"
+
+            # Read metadata to find partial ISO
+            local metadata=$(read_pipeline_state "$state_file")
+            local iso_path=$(parse_json_field "$metadata" "iso_path")
+
+            # Remove partial ISO and mapfile
+            if [[ -n "$iso_path" ]]; then
+                cleanup_files "$iso_path" "${iso_path}.mapfile"
+            fi
+
+            remove_state_file "$state_file"
+        done <<< "$interrupted"
+    fi
+}
+
+# ============================================================================
+# Main Entry Point
+# ============================================================================
+
+main() {
+    local device="${1:-$DVD_DEVICE}"
+
+    # Initialize
+    init_logging || exit 1
+    ensure_staging_dir
+
+    log_info "[ISO] ==================== DVD ISO Creator Started ===================="
+    log_info "[ISO] Device: $device"
+
+    # Acquire stage lock (non-blocking for ISO stage)
+    if ! acquire_stage_lock "iso"; then
+        log_error "[ISO] Another ISO creation is already running"
+        exit 1
+    fi
+
+    # Set up cleanup trap
+    trap 'release_stage_lock "iso"; log_info "[ISO] DVD ISO Creator stopped"' EXIT INT TERM
+
+    # Check for recovery scenarios
+    check_iso_recovery
+
+    # Wait for device to be ready
+    if ! wait_for_device "$device" 30; then
+        log_error "[ISO] Device not ready or no disc present"
+        exit 1
+    fi
+
+    # Verify it's a readable DVD
+    if ! is_dvd_readable "$device"; then
+        log_error "[ISO] Device is not a readable DVD"
+        exit 1
+    fi
+
+    # Check disk space before creating ISO
+    if ! check_disk_space "$STAGING_DIR"; then
+        log_error "[ISO] Insufficient disk space, ejecting disc"
+        eject_disc "$device"
+        exit 1
+    fi
+
+    # Create the ISO
+    create_dvd_iso "$device"
+    local exit_code=$?
+
+    if [[ $exit_code -eq 0 ]]; then
+        log_info "[ISO] ISO creation completed successfully"
+        local pending=$(count_pending_state "iso-ready")
+        log_info "[ISO] ISOs pending encoding: $pending"
+    elif [[ $exit_code -eq 2 ]]; then
+        log_info "[ISO] ISO creation skipped (duplicate)"
+    else
+        log_error "[ISO] ISO creation failed"
+    fi
+
+    exit $exit_code
+}
+
+# Run main function if script is executed directly
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/scripts/dvd-transfer.sh
+++ b/scripts/dvd-transfer.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+# DVD Transfer - Stage 3 of Pipeline
+# Transfers ONE encoded video to NAS/Plex server per run
+# Run via cron/systemd timer every 15 minutes
+
+set -euo pipefail
+
+# Get script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source utility functions
+source "${SCRIPT_DIR}/dvd-utils.sh"
+
+# Configuration (overridden by config file)
+NAS_ENABLED="${NAS_ENABLED:-0}"
+CLEANUP_MKV_AFTER_TRANSFER="${CLEANUP_MKV_AFTER_TRANSFER:-1}"
+CLEANUP_ISO_AFTER_TRANSFER="${CLEANUP_ISO_AFTER_TRANSFER:-1}"
+
+# ============================================================================
+# Transfer Function
+# ============================================================================
+
+transfer_video() {
+    local state_file="$1"
+    local metadata mkv_path iso_path sanitized_title year timestamp
+    local state_file_transferring
+
+    log_info "[TRANSFER] Processing: $state_file"
+
+    # Read metadata from state file
+    metadata=$(read_pipeline_state "$state_file")
+
+    # Parse metadata
+    sanitized_title=$(parse_json_field "$metadata" "title")
+    year=$(parse_json_field "$metadata" "year")
+    timestamp=$(parse_json_field "$metadata" "timestamp")
+    mkv_path=$(parse_json_field "$metadata" "mkv_path")
+    iso_path=$(parse_json_field "$metadata" "iso_path")
+
+    log_info "[TRANSFER] Title: '$sanitized_title', Year: '$year'"
+    log_info "[TRANSFER] MKV: $mkv_path"
+
+    # Verify MKV exists
+    if [[ ! -f "$mkv_path" ]]; then
+        log_error "[TRANSFER] MKV file not found: $mkv_path"
+        log_warn "[TRANSFER] Removing orphaned state file"
+        remove_state_file "$state_file"
+        return 1
+    fi
+
+    # Check NAS configuration
+    if [[ -z "$NAS_HOST" ]] || [[ -z "$NAS_USER" ]] || [[ -z "$NAS_PATH" ]]; then
+        log_error "[TRANSFER] NAS configuration incomplete (NAS_HOST, NAS_USER, NAS_PATH required)"
+        return 1
+    fi
+
+    # Transition state: encoded-ready -> transferring
+    remove_state_file "$state_file"
+    state_file_transferring=$(create_pipeline_state "transferring" "$sanitized_title" "$timestamp" "$metadata")
+
+    local mkv_size=$(stat -c%s "$mkv_path" 2>/dev/null || echo "0")
+    local mkv_size_mb=$((mkv_size / 1024 / 1024))
+    log_info "[TRANSFER] Starting transfer (${mkv_size_mb}MB) to ${NAS_USER}@${NAS_HOST}:${NAS_PATH}"
+
+    # Perform transfer
+    if transfer_to_nas "$mkv_path"; then
+        log_info "[TRANSFER] Transfer successful"
+
+        # Cleanup local MKV if configured
+        if [[ "$CLEANUP_MKV_AFTER_TRANSFER" == "1" ]]; then
+            log_info "[TRANSFER] Removing local MKV: $mkv_path"
+            rm -f "$mkv_path"
+        fi
+
+        # Cleanup ISO.deletable if configured and exists
+        if [[ "$CLEANUP_ISO_AFTER_TRANSFER" == "1" ]]; then
+            local iso_deletable="${iso_path}.deletable"
+            if [[ -f "$iso_deletable" ]]; then
+                log_info "[TRANSFER] Removing ISO: $iso_deletable"
+                rm -f "$iso_deletable"
+            fi
+            # Also try without .deletable suffix (in case it wasn't renamed)
+            if [[ -f "$iso_path" ]]; then
+                log_info "[TRANSFER] Removing ISO: $iso_path"
+                rm -f "$iso_path"
+            fi
+        fi
+
+        # Remove state file - transfer complete
+        remove_state_file "$state_file_transferring"
+
+        log_info "[TRANSFER] Transfer complete: $sanitized_title"
+        return 0
+    else
+        log_error "[TRANSFER] Transfer failed"
+
+        # Revert state back to encoded-ready for future retry
+        remove_state_file "$state_file_transferring"
+        create_pipeline_state "encoded-ready" "$sanitized_title" "$timestamp" "$metadata" > /dev/null
+
+        log_warn "[TRANSFER] Video returned to queue for retry"
+        return 1
+    fi
+}
+
+# ============================================================================
+# Recovery Function
+# ============================================================================
+
+check_transfer_recovery() {
+    log_info "[TRANSFER] Checking for interrupted transfer operations..."
+
+    # Check for interrupted transfers
+    local interrupted=$(find_state_files "transferring")
+    if [[ -n "$interrupted" ]]; then
+        log_warn "[TRANSFER] Found interrupted transfer"
+        while IFS= read -r state_file; do
+            log_info "[TRANSFER] Checking interrupted transfer: $state_file"
+
+            # Read metadata
+            local metadata=$(read_pipeline_state "$state_file")
+            local mkv_path=$(parse_json_field "$metadata" "mkv_path")
+            local sanitized_title=$(parse_json_field "$metadata" "title")
+            local timestamp=$(parse_json_field "$metadata" "timestamp")
+
+            # Check if local file still exists
+            if [[ -f "$mkv_path" ]]; then
+                log_info "[TRANSFER] Local file exists, returning to queue for retry"
+                remove_state_file "$state_file"
+                create_pipeline_state "encoded-ready" "$sanitized_title" "$timestamp" "$metadata" > /dev/null
+            else
+                # File was likely transferred and cleaned up, but state wasn't updated
+                log_info "[TRANSFER] Local file gone (transfer likely completed), removing state"
+                remove_state_file "$state_file"
+            fi
+        done <<< "$interrupted"
+    fi
+}
+
+# ============================================================================
+# Main Entry Point
+# ============================================================================
+
+main() {
+    # Initialize
+    init_logging || exit 1
+    ensure_staging_dir
+
+    log_info "[TRANSFER] ==================== DVD Transfer Started ===================="
+
+    # Check if NAS transfer is enabled
+    if [[ "$NAS_ENABLED" != "1" ]]; then
+        log_info "[TRANSFER] NAS transfer disabled (NAS_ENABLED != 1)"
+        exit 0
+    fi
+
+    # Try to acquire stage lock (non-blocking)
+    if ! acquire_stage_lock "transfer"; then
+        log_info "[TRANSFER] Another transfer is already running, exiting"
+        exit 0
+    fi
+
+    # Set up cleanup trap
+    trap 'release_stage_lock "transfer"; log_info "[TRANSFER] DVD Transfer stopped"' EXIT INT TERM
+
+    # Check for recovery scenarios
+    check_transfer_recovery
+
+    # Find oldest encoded-ready state file
+    local state_file=$(find_oldest_state "encoded-ready")
+
+    if [[ -z "$state_file" ]]; then
+        log_info "[TRANSFER] No videos pending transfer"
+        exit 0
+    fi
+
+    local pending=$(count_pending_state "encoded-ready")
+    log_info "[TRANSFER] Found $pending video(s) pending transfer"
+    log_info "[TRANSFER] Processing oldest: $state_file"
+
+    # Transfer the video
+    transfer_video "$state_file"
+    local exit_code=$?
+
+    if [[ $exit_code -eq 0 ]]; then
+        log_info "[TRANSFER] Transfer completed successfully"
+        local remaining=$(count_pending_state "encoded-ready")
+        log_info "[TRANSFER] Videos remaining: $remaining"
+    else
+        log_error "[TRANSFER] Transfer failed"
+    fi
+
+    exit $exit_code
+}
+
+# Run main function if script is executed directly
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi


### PR DESCRIPTION
## Summary

Split DVD ripping into a decoupled 3-stage pipeline for reliability and efficiency:

| Stage | Trigger | Script | Purpose |
|-------|---------|--------|---------|
| 1 | udev (disc insert) | `dvd-iso.sh` | Create ISO, eject immediately |
| 2 | systemd timer (15 min) | `dvd-encoder.sh` | Encode ONE ISO to MKV |
| 3 | systemd timer (15 min) | `dvd-transfer.sh` | Transfer ONE video to NAS |

### Benefits
- **Drive freed immediately** - disc ejected after ISO creation (~30 min vs 2-4 hours)
- **Resumable** - ddrescue can resume interrupted ISO creation
- **Decoupled** - encoding/transfer failures don't affect disc operations
- **Queue-based** - multiple ISOs can queue up for encoding

### New Files
- `scripts/dvd-iso.sh` - Stage 1: ISO creation
- `scripts/dvd-encoder.sh` - Stage 2: HandBrake encoding
- `scripts/dvd-transfer.sh` - Stage 3: NAS transfer
- `config/dvd-encoder.{service,timer}` - Systemd units for encoding
- `config/dvd-transfer.{service,timer}` - Systemd units for transfer
- `CONTRIBUTING.md` - Branch strategy guide
- `WORKLIST.md` - Future improvements backlog

### Updated Files
- `dvd-utils.sh` - Pipeline lock/state helper functions
- `remote-install.sh` - Install pipeline components and timers
- `CLAUDE.md` - Architecture documentation
- `config/dvd-ripper.conf.example` - Pipeline mode settings
- `config/99-dvd-ripper.rules` - Calls dvd-iso.sh

## Test plan
- [ ] Install on test server with `sudo ./remote-install.sh --install-libdvdcss`
- [ ] Verify timers are enabled: `systemctl list-timers | grep dvd`
- [ ] Insert DVD and verify ISO creation + immediate eject
- [ ] Verify encoder picks up ISO within 15 minutes
- [ ] Verify transfer to NAS (if configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)