### PR TITLE
feat: Add Plex-friendly naming convention

### DIFF
--- a/WORKLIST.md
+++ b/WORKLIST.md
@@ -1,10 +1,11 @@
 # DVD Auto-Ripper Worklist
 
-Future improvements and backlog items.
+Future improvements and backlog items. See [GitHub Issues](https://github.com/mschober/dvd-auto-ripper/issues) for tracking.
 
 ## Pending Items
 
 ### Plex-Ready Naming Convention
+- **Issue:** [#2](https://github.com/mschober/dvd-auto-ripper/issues/2)
 - **Priority:** High
 - **Description:** Update video naming to use Plex-compatible format
 - **Current:** `The_Matrix-1999-1703615234.mkv`
@@ -17,11 +18,13 @@ Future improvements and backlog items.
   - Handle TV shows differently: `Show Name - S01E01 - Episode Title.mkv`
 
 ### ISO Cleanup Job
+- **Issue:** [#3](https://github.com/mschober/dvd-auto-ripper/issues/3)
 - **Priority:** Medium
 - **Description:** Create monthly cron job to delete `*.iso.deletable` files
 - **Notes:** Files are marked `.deletable` after successful encoding
 
 ### Metadata Lookup Integration
+- **Issue:** [#4](https://github.com/mschober/dvd-auto-ripper/issues/4)
 - **Priority:** Low
 - **Description:** Integrate with TMDb or OMDb API for accurate movie metadata
 - **Notes:**
@@ -30,11 +33,13 @@ Future improvements and backlog items.
   - Requires API key configuration
 
 ### Web UI for Monitoring
+- **Issue:** [#5](https://github.com/mschober/dvd-auto-ripper/issues/5)
 - **Priority:** Low
 - **Description:** Simple web interface to view queue status and logs
 - **Notes:** Could show pending ISOs, encoding progress, transfer status
 
 ### Email/Notification on Completion
+- **Issue:** [#6](https://github.com/mschober/dvd-auto-ripper/issues/6)
 - **Priority:** Low
 - **Description:** Send notification when rip/encode/transfer completes
 - **Notes:** Could integrate with email, Slack, Discord, etc.

--- a/scripts/dvd-encoder.sh
+++ b/scripts/dvd-encoder.sh
@@ -48,8 +48,8 @@ encode_iso() {
         return 1
     fi
 
-    # Generate output filename
-    output_filename=$(generate_filename "$sanitized_title" "$year" "$HANDBRAKE_FORMAT")
+    # Generate Plex-friendly output filename (e.g., "The Matrix (1999).mkv")
+    output_filename=$(generate_plex_filename "$sanitized_title" "$year" "$HANDBRAKE_FORMAT")
     output_path="${STAGING_DIR}/${output_filename}"
 
     # Update metadata with MKV path


### PR DESCRIPTION
## Summary
- Adds Plex-compatible output naming: `The Matrix (1999).mkv` instead of `THE_MATRIX-1999-1703615234.mkv`
- Implements `clean_title_for_plex()` for title formatting (underscores → spaces, title case)
- Implements `generate_plex_filename()` for the final output format
- Updates `dvd-encoder.sh` to use the new naming scheme

## Test plan
- [x] Verified `clean_title_for_plex` correctly transforms titles:
  - `THE_MATRIX` → `The Matrix`
  - `FORREST_GUMP` → `Forrest Gump`
- [x] Verified `generate_plex_filename` output format:
  - With year: `The Matrix (1999).mkv`
  - Without year: `Unknown Movie.mkv`
- [ ] End-to-end test with actual DVD rip

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)