### PR TITLE
Feature: Add dvd-dashboard-ctl.sh for dashboard control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `dvd-dashboard-ctl.sh` script for start/stop/restart/status of web dashboard
+
 ## [1.1.0] - 2025-01-05
 
 ### Added

--- a/remote-install.sh
+++ b/remote-install.sh
@@ -284,6 +284,7 @@ install_scripts() {
     cp "$SCRIPT_DIR/scripts/dvd-ripper-services-start.sh" "$INSTALL_BIN/"
     cp "$SCRIPT_DIR/scripts/dvd-ripper-trigger-pause.sh" "$INSTALL_BIN/"
     cp "$SCRIPT_DIR/scripts/dvd-ripper-trigger-resume.sh" "$INSTALL_BIN/"
+    cp "$SCRIPT_DIR/scripts/dvd-dashboard-ctl.sh" "$INSTALL_BIN/"
 
     # Copy pipeline scripts (3-stage mode)
     cp "$SCRIPT_DIR/scripts/dvd-iso.sh" "$INSTALL_BIN/"
@@ -303,6 +304,7 @@ install_scripts() {
     chmod 755 "$INSTALL_BIN/dvd-ripper-services-start.sh"
     chmod 755 "$INSTALL_BIN/dvd-ripper-trigger-pause.sh"
     chmod 755 "$INSTALL_BIN/dvd-ripper-trigger-resume.sh"
+    chmod 755 "$INSTALL_BIN/dvd-dashboard-ctl.sh"
     chmod 755 "$INSTALL_BIN/dvd-iso.sh"
     chmod 755 "$INSTALL_BIN/dvd-encoder.sh"
     chmod 755 "$INSTALL_BIN/dvd-transfer.sh"

--- a/scripts/dvd-dashboard-ctl.sh
+++ b/scripts/dvd-dashboard-ctl.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Control the DVD ripper web dashboard service
+# Usage: dvd-dashboard-ctl.sh [start|stop|restart|status]
+
+set -euo pipefail
+
+SERVICE="dvd-dashboard.service"
+
+usage() {
+    echo "Usage: $0 {start|stop|restart|status}"
+    echo ""
+    echo "Commands:"
+    echo "  start    Start the web dashboard"
+    echo "  stop     Stop the web dashboard"
+    echo "  restart  Restart the web dashboard"
+    echo "  status   Show dashboard status"
+    exit 1
+}
+
+start_dashboard() {
+    echo "Starting DVD dashboard..."
+    if systemctl start "$SERVICE"; then
+        echo "Dashboard started successfully"
+        show_url
+    else
+        echo "Failed to start dashboard"
+        exit 1
+    fi
+}
+
+stop_dashboard() {
+    echo "Stopping DVD dashboard..."
+    if systemctl stop "$SERVICE"; then
+        echo "Dashboard stopped"
+    else
+        echo "Failed to stop dashboard"
+        exit 1
+    fi
+}
+
+restart_dashboard() {
+    echo "Restarting DVD dashboard..."
+    if systemctl restart "$SERVICE"; then
+        echo "Dashboard restarted successfully"
+        show_url
+    else
+        echo "Failed to restart dashboard"
+        exit 1
+    fi
+}
+
+show_status() {
+    echo "DVD Dashboard Status"
+    echo "===================="
+    systemctl status "$SERVICE" --no-pager 2>/dev/null || echo "Service not found or not running"
+}
+
+show_url() {
+    # Try to get the dashboard URL from the service
+    local ip
+    ip=$(hostname -I 2>/dev/null | awk '{print $1}')
+    if [[ -n "$ip" ]]; then
+        echo ""
+        echo "Dashboard URL: http://${ip}:5000"
+    fi
+}
+
+# Main
+if [[ $# -lt 1 ]]; then
+    usage
+fi
+
+case "$1" in
+    start)
+        start_dashboard
+        ;;
+    stop)
+        stop_dashboard
+        ;;
+    restart)
+        restart_dashboard
+        ;;
+    status)
+        show_status
+        ;;
+    *)
+        usage
+        ;;
+esac


### PR DESCRIPTION
## Summary
- Add `dvd-dashboard-ctl.sh` script for controlling the web dashboard
- Commands: start, stop, restart, status
- Displays dashboard URL on start/restart

## Usage
```bash
dvd-dashboard-ctl.sh start    # Start the dashboard
dvd-dashboard-ctl.sh stop     # Stop the dashboard
dvd-dashboard-ctl.sh restart  # Restart the dashboard
dvd-dashboard-ctl.sh status   # Show dashboard status
```

## Test plan
- [ ] Run `dvd-dashboard-ctl.sh status` to verify status display
- [ ] Run `dvd-dashboard-ctl.sh stop` then `start` to test control
- [ ] Verify dashboard URL is displayed on start

🤖 Generated with [Claude Code](https://claude.com/claude-code)