### PR TITLE
feat: Add dedicated dashboard install script with auto-restart

### DIFF
--- a/remote-install.sh
+++ b/remote-install.sh
@@ -542,46 +542,14 @@ install_udev_rule() {
 install_web_dashboard() {
     print_info "Installing web dashboard..."
 
-    local dashboard_source="$SCRIPT_DIR/web/dvd-dashboard.py"
-    local service_source="$SCRIPT_DIR/config/dvd-dashboard.service"
-    local systemd_dir="/etc/systemd/system"
+    local install_script="$SCRIPT_DIR/scripts/dvd-dashboard-install.sh"
 
-    # Check if dashboard exists
-    if [[ ! -f "$dashboard_source" ]]; then
-        print_warn "Web dashboard not found at $dashboard_source, skipping"
-        return
-    fi
-
-    # Check if Flask is installed
-    if ! python3 -c "import flask" 2>/dev/null; then
-        print_info "Installing Flask..."
-        if command -v apt-get &>/dev/null; then
-            apt-get install -y python3-flask >/dev/null 2>&1 || pip3 install flask
-        elif command -v pip3 &>/dev/null; then
-            pip3 install flask
-        else
-            print_warn "Cannot install Flask - please install manually: pip3 install flask"
-            return
-        fi
-    fi
-
-    # Install dashboard script
-    cp "$dashboard_source" "$INSTALL_BIN/dvd-dashboard.py"
-    chmod 755 "$INSTALL_BIN/dvd-dashboard.py"
-
-    # Install systemd service
-    if [[ -f "$service_source" ]]; then
-        cp "$service_source" "$systemd_dir/"
-        chmod 644 "$systemd_dir/dvd-dashboard.service"
-        systemctl daemon-reload
-        systemctl enable dvd-dashboard.service
-        systemctl restart dvd-dashboard.service
-
-        # Get dashboard version
-        local dashboard_version=$(grep -oP 'DASHBOARD_VERSION = "\K[^"]+' "$dashboard_source" 2>/dev/null || echo "unknown")
-        print_info "✓ Web dashboard v${dashboard_version} installed and started"
+    # Check if dedicated install script exists
+    if [[ -f "$install_script" ]]; then
+        # Delegate to dedicated install script
+        bash "$install_script" "$SCRIPT_DIR"
     else
-        print_warn "dvd-dashboard.service not found, skipping systemd integration"
+        print_warn "Dashboard install script not found at $install_script, skipping"
     fi
 }
 

--- a/scripts/dvd-dashboard-install.sh
+++ b/scripts/dvd-dashboard-install.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Install/Update the DVD Ripper Web Dashboard
+# Usage: sudo ./dvd-dashboard-install.sh [SOURCE_DIR]
+#
+# This script installs the web dashboard and restarts the service if running.
+# Called by remote-install.sh or can be run standalone.
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+print_info() { echo -e "${GREEN}[INFO]${NC} $*"; }
+print_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+print_error() { echo -e "${RED}[ERROR]${NC} $*"; }
+
+# Installation paths
+INSTALL_BIN="/usr/local/bin"
+SYSTEMD_DIR="/etc/systemd/system"
+SERVICE_NAME="dvd-dashboard.service"
+
+# Source directory (where this script is located, or passed as argument)
+if [[ $# -ge 1 ]]; then
+    SOURCE_DIR="$1"
+else
+    # Default to parent of scripts directory
+    SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+
+DASHBOARD_SOURCE="$SOURCE_DIR/web/dvd-dashboard.py"
+SERVICE_SOURCE="$SOURCE_DIR/config/dvd-dashboard.service"
+
+# Check if running as root
+if [[ $EUID -ne 0 ]]; then
+    print_error "This script must be run as root (use sudo)"
+    exit 1
+fi
+
+# Check if dashboard source exists
+if [[ ! -f "$DASHBOARD_SOURCE" ]]; then
+    print_error "Dashboard source not found: $DASHBOARD_SOURCE"
+    exit 1
+fi
+
+# Check if Flask is installed
+if ! python3 -c "import flask" 2>/dev/null; then
+    print_info "Installing Flask..."
+    if command -v apt-get &>/dev/null; then
+        apt-get install -y python3-flask >/dev/null 2>&1 || pip3 install flask
+    elif command -v pip3 &>/dev/null; then
+        pip3 install flask
+    else
+        print_error "Cannot install Flask - please install manually: pip3 install flask"
+        exit 1
+    fi
+fi
+
+# Get version from source file
+DASHBOARD_VERSION=$(grep -oP 'DASHBOARD_VERSION = "\K[^"]+' "$DASHBOARD_SOURCE" 2>/dev/null || echo "unknown")
+
+# Check if service is currently running
+SERVICE_WAS_RUNNING=false
+if systemctl is-active "$SERVICE_NAME" &>/dev/null; then
+    SERVICE_WAS_RUNNING=true
+    print_info "Dashboard service is running, will restart after install"
+fi
+
+# Install dashboard script
+print_info "Installing dvd-dashboard.py to $INSTALL_BIN..."
+cp "$DASHBOARD_SOURCE" "$INSTALL_BIN/dvd-dashboard.py"
+chmod 755 "$INSTALL_BIN/dvd-dashboard.py"
+
+# Install systemd service if source exists
+if [[ -f "$SERVICE_SOURCE" ]]; then
+    print_info "Installing systemd service..."
+    cp "$SERVICE_SOURCE" "$SYSTEMD_DIR/"
+    chmod 644 "$SYSTEMD_DIR/$SERVICE_NAME"
+    systemctl daemon-reload
+    systemctl enable "$SERVICE_NAME"
+fi
+
+# Start or restart the service
+if [[ "$SERVICE_WAS_RUNNING" == "true" ]]; then
+    print_info "Restarting dashboard service..."
+    systemctl restart "$SERVICE_NAME"
+else
+    print_info "Starting dashboard service..."
+    systemctl start "$SERVICE_NAME"
+fi
+
+# Verify service started
+if systemctl is-active "$SERVICE_NAME" &>/dev/null; then
+    local_ip=$(hostname -I 2>/dev/null | awk '{print $1}')
+    print_info "Web dashboard v${DASHBOARD_VERSION} installed and running"
+    print_info "Dashboard URL: http://${local_ip:-localhost}:5000"
+else
+    print_error "Dashboard service failed to start"
+    print_error "Check logs: journalctl -u $SERVICE_NAME -n 20"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Create `scripts/dvd-dashboard-install.sh` for standalone dashboard installation
- Automatically restarts service if already running (fixes update not taking effect)
- Refactor `remote-install.sh` to delegate to the new script

## Test plan
- [x] Run `sudo ./scripts/dvd-dashboard-install.sh` and verify dashboard restarts with new version
- [x] Verify udev trigger panel appears on `/status` page

🤖 Generated with [Claude Code](https://claude.com/claude-code)