### PR TITLE
Feature: Identify page dismiss, auto-refresh, and NAS rename fixes

### DIFF
--- a/features/pending-identification/PREVIEW.md
+++ b/features/pending-identification/PREVIEW.md
@@ -1,0 +1,132 @@
+# Preview & Identification Guide
+
+## What Are Previews?
+
+When a DVD is ripped and encoded, the system generates a short preview clip from the movie. This clip helps you identify discs that had generic or missing title metadata — names like `DVD_VIDEO`, `DISC1`, or `DVD_20251227_143022` instead of the actual movie title.
+
+Previews are 2-minute MP4 clips, starting 25% into the movie to skip past studio logos and menu loops. They play directly in your browser on the dashboard.
+
+## When Are Previews Created?
+
+Previews are generated automatically during Stage 2 (encoding) for **every** disc, regardless of whether the title looks correct. This is intentional — even discs with plausible-looking names can be wrong (e.g., a bonus disc labeled `MAIN_FEATURE`).
+
+Preview generation requires `ffmpeg` and `ffprobe`. If either is missing, the system logs a warning and continues without a preview. You can still identify items by filename alone.
+
+## Identifying and Renaming Movies
+
+### Finding Items That Need Attention
+
+Open the dashboard at `http://<server>:5000` and look for the **Pending ID** link in the navigation. A count badge appears when items need identification.
+
+The `/identify` page has two sections:
+
+- **Needs Identification** — Discs with generic names detected by the system
+- **Audit Flags** — Items flagged by the hourly audit for suspicious titles, small files, or missing archives
+
+### The Rename Workflow
+
+Each item on the page shows:
+
+1. **Video preview** — Watch the clip to figure out what movie this is
+2. **Current name** — The raw disc title, displayed for reference
+3. **Pipeline state** — Where the item is in processing (e.g., `encoded-ready`, `transferred`)
+4. **Title field** — Enter the correct movie title
+5. **Year field** — Enter the 4-digit release year (optional but recommended for Plex)
+
+Click **Rename & Identify** to apply. The system renames:
+
+- The MKV file → Plex format: `Movie Title (2024).mkv`
+- The ISO or dvdbackup directory (if still on disk)
+- The `.archive-ready` marker (if present)
+- The preview clip
+- The NAS copy (if already transferred, via SSH)
+
+The card fades out on success. If all items are handled, the page reloads automatically.
+
+### Plex Naming Format
+
+Plex expects movie files named as:
+
+```
+Movie Title (2024).mkv
+```
+
+The rename operation applies this format automatically. Enter the title in natural case (e.g., `The Matrix`, not `THE_MATRIX`) and the system handles the rest. If you omit the year, the file is named `Movie Title.mkv` — this works but Plex matching is more reliable with a year.
+
+### When Can You Rename?
+
+Renaming is available in these pipeline states:
+
+| State | Meaning |
+|-------|---------|
+| `iso-ready` | ISO created, waiting for encode |
+| `encoded-ready` | Encoded, waiting for NAS transfer |
+| `transferred` | On NAS (rename happens locally and remotely) |
+
+Items in active states (`iso-creating`, `encoding`, `transferring`) cannot be renamed until processing completes.
+
+## Configuration
+
+These settings go in `/etc/dvd-ripper.conf`:
+
+```bash
+# Enable or disable preview generation (0=disabled, 1=enabled)
+GENERATE_PREVIEWS="1"
+
+# Preview clip length in seconds
+PREVIEW_DURATION="120"
+
+# Where in the movie to start the preview, as a percentage
+# 25 = one quarter in, past studio logos and ads
+PREVIEW_START_PERCENT="25"
+
+# Output resolution in ffmpeg scale format
+# 640:360 (360p), 854:480 (480p), 1280:720 (720p)
+PREVIEW_RESOLUTION="640:360"
+
+# Delete preview files after NAS transfer (0=keep, 1=delete)
+# Keep them if you want to identify movies after transfer
+CLEANUP_PREVIEW_AFTER_TRANSFER="0"
+```
+
+### Tuning Tips
+
+- **Longer previews** — Increase `PREVIEW_DURATION` if 2 minutes isn't enough to recognize a movie. Previews are low-resolution, so even 5 minutes is a small file.
+- **Different start point** — If previews keep landing on opening credits, raise `PREVIEW_START_PERCENT` to 30 or 35.
+- **Skip previews entirely** — Set `GENERATE_PREVIEWS="0"` if you always know what disc you're inserting. You can still rename items by filename on the identify page.
+
+## Generic Title Detection
+
+The system flags these patterns as needing identification:
+
+| Pattern | Example |
+|---------|---------|
+| Fallback timestamp | `DVD_20251227_143022` |
+| Generic volume labels | `DVD`, `DVD_VIDEO`, `DVDVIDEO` |
+| Disc labels | `DISC1`, `DISK2` |
+| Raw folder names | `VIDEO_TS` |
+| Authoring defaults | `MYDVD` |
+| Very short titles | Any title 3 characters or shorter |
+
+Discs with titles that don't match these patterns are assumed to be correctly named. They still get previews (if enabled) but won't appear on the identification page unless flagged by the audit.
+
+## Troubleshooting
+
+**No preview available for an item:**
+- Check that `ffmpeg` and `ffprobe` are installed: `which ffmpeg ffprobe`
+- Check the log for errors: `grep -i preview /var/log/dvd-ripper.log`
+- The video may have been too short or unreadable for ffprobe to determine duration
+
+**Preview shows wrong part of the movie:**
+- Adjust `PREVIEW_START_PERCENT` in `/etc/dvd-ripper.conf`
+- Some DVDs have unusual chapter layouts that shift the effective start point
+
+**Rename fails with NAS error:**
+- The NAS must be reachable via SSH for transferred items
+- Check SSH connectivity: `ssh <nas-host> ls <nas-path>`
+- You can retry the rename later — the item stays on the identify page
+
+**Item doesn't appear on identify page:**
+- Only items with `needs_identification: true` in their state metadata appear automatically
+- Items in active processing states (`encoding`, `transferring`) won't show until processing completes
+- Check state files: `ls /var/tmp/dvd-rips/*.iso-ready /var/tmp/dvd-rips/*.encoded-ready /var/tmp/dvd-rips/*.transferred`

--- a/scripts/dvd-encoder.sh
+++ b/scripts/dvd-encoder.sh
@@ -121,6 +121,9 @@ generate_preview() {
         -movflags +faststart \
         -y "$preview_path" >> "$(get_stage_log_file)" 2>&1; then
 
+        # Make group-writable so dvd-web can delete via dashboard
+        chgrp dvd-ripper "$preview_path" 2>/dev/null || true
+        chmod 664 "$preview_path" 2>/dev/null || true
         local preview_size=$(stat -c%s "$preview_path" 2>/dev/null || echo "0")
         local preview_size_mb=$((preview_size / 1024 / 1024))
         log_info "[ENCODER] Preview generated: ${preview_size_mb}MB at $preview_path"

--- a/web/helpers/identifier.py
+++ b/web/helpers/identifier.py
@@ -222,17 +222,20 @@ class Identifier:
             new_mkv = os.path.join(STAGING_DIR, new_mkv_name)
             os.rename(old_mkv, new_mkv)
 
-        # Rename ISO if exists (could be .iso or .iso.deletable)
-        if old_iso:
-            iso_deletable = old_iso + '.deletable'
-            if os.path.exists(iso_deletable):
-                new_iso_name = f"{new_sanitized}-{timestamp}.iso.deletable"
-                new_iso = os.path.join(STAGING_DIR, new_iso_name).replace('.deletable', '')
-                os.rename(iso_deletable, new_iso + '.deletable')
-            elif os.path.exists(old_iso):
-                new_iso_name = f"{new_sanitized}-{timestamp}.iso"
-                new_iso = os.path.join(STAGING_DIR, new_iso_name)
-                os.rename(old_iso, new_iso)
+        # Rename rip if exists (ISO file from ddrescue, or directory from dvdbackup)
+        if old_iso and os.path.exists(old_iso):
+            if os.path.isdir(old_iso):
+                # dvdbackup: directory with no extension
+                new_iso = os.path.join(STAGING_DIR, f"{new_sanitized}-{timestamp}")
+            else:
+                # ddrescue: .iso file
+                new_iso = os.path.join(STAGING_DIR, f"{new_sanitized}-{timestamp}.iso")
+            os.rename(old_iso, new_iso)
+
+            # Rename .archive-ready marker if it exists
+            old_marker = old_iso + ".archive-ready"
+            if os.path.exists(old_marker):
+                os.rename(old_marker, new_iso + ".archive-ready")
 
         # Rename preview if exists
         if old_preview and os.path.exists(old_preview):

--- a/web/helpers/identifier.py
+++ b/web/helpers/identifier.py
@@ -71,10 +71,14 @@ class Identifier:
 
     @staticmethod
     def get_pending_identification():
-        """Get items that need identification (generic names in renameable states).
+        """Get items that need identification or year in renameable states.
+
+        Shows any item that has a preview file and is missing a valid
+        4-digit year, plus any item explicitly flagged via
+        needs_identification.
 
         Returns:
-            list: Items needing identification sorted by modification time.
+            list: Items needing attention sorted by modification time.
         """
         pending = []
         for state in RENAMEABLE_STATES:
@@ -87,10 +91,14 @@ class Identifier:
                     continue
 
                 title = metadata.get('title', '')
-                # Check explicit flag first, fall back to pattern matching
-                needs_id = metadata.get('needs_identification', Identifier.is_generic_title(title))
+                year = metadata.get('year', '').strip()
+                has_year = bool(re.match(r'^\d{4}$', year))
+                preview_path = metadata.get('preview_path', '').strip()
+                has_preview = bool(preview_path) and os.path.isfile(preview_path)
 
-                if needs_id:
+                needs_id = metadata.get('needs_identification', Identifier.is_generic_title(title))
+                # Show if explicitly flagged, or has a preview but missing a year
+                if needs_id or (has_preview and not has_year):
                     pending.append({
                         "state_file": os.path.basename(state_file),
                         "state": state,

--- a/web/helpers/identifier.py
+++ b/web/helpers/identifier.py
@@ -152,11 +152,11 @@ class Identifier:
         Returns:
             dict: NAS host, user, and path.
         """
-        config = ConfigManager.read()
+        config = ConfigManager.read(mask_sensitive=False)
         return {
-            "host": config.get("NAS_HOST", "").replace("***", ""),  # Config may be masked
-            "user": config.get("NAS_USER", "").replace("***", ""),
-            "path": config.get("NAS_PATH", "").replace("***", "")
+            "host": config.get("NAS_HOST", ""),
+            "user": config.get("NAS_USER", ""),
+            "path": config.get("NAS_PATH", "")
         }
 
     @staticmethod

--- a/web/pages/api_identify.py
+++ b/web/pages/api_identify.py
@@ -83,3 +83,21 @@ def api_serve_preview(filename):
         return jsonify({"error": "Preview not found"}), 404
 
     return send_file(preview_path, mimetype='video/mp4')
+
+
+@api_identify_bp.route("/api/preview/<filename>", methods=["DELETE"])
+def api_delete_preview(filename):
+    """API: Delete a preview video file."""
+    # Security: only allow .preview.mp4 files
+    if not filename.endswith('.preview.mp4'):
+        return jsonify({"error": "Invalid preview file"}), 400
+
+    preview_path = os.path.join(STAGING_DIR, filename)
+    if not os.path.exists(preview_path):
+        return jsonify({"error": "Preview not found"}), 404
+
+    try:
+        os.remove(preview_path)
+        return jsonify({"status": "deleted"})
+    except OSError as e:
+        return jsonify({"error": str(e)}), 500

--- a/web/pages/api_identify.py
+++ b/web/pages/api_identify.py
@@ -1,7 +1,10 @@
 """Identification API routes for the DVD ripper dashboard."""
+import logging
 import os
 import re
 from flask import Blueprint, jsonify, request, send_file
+
+logger = logging.getLogger(__name__)
 
 from helpers.pipeline import STAGING_DIR
 from helpers.identifier import Identifier, RENAMEABLE_STATES
@@ -98,6 +101,8 @@ def api_delete_preview(filename):
 
     try:
         os.remove(preview_path)
+        logger.info("Deleted preview: %s", filename)
         return jsonify({"status": "deleted"})
     except OSError as e:
+        logger.error("Failed to delete preview %s: %s", filename, e)
         return jsonify({"error": str(e)}), 500

--- a/web/pages/dashboard.py
+++ b/web/pages/dashboard.py
@@ -164,8 +164,6 @@ def issues_page():
     return render_template(
         "identify.html",
         active_page="issues",
-        pending=Identifier.get_pending_identification(),
-        audit_flags=Identifier.get_audit_flags(),
         version=get_pipeline_version(),
         dashboard_version=DASHBOARD_VERSION,
         github_url=GITHUB_URL,

--- a/web/static/js/identify.js
+++ b/web/static/js/identify.js
@@ -59,6 +59,38 @@ async function handleRename(form, event) {
     return false;
 }
 
+async function dismissPreview(btn) {
+    const card = btn.closest('.identify-card');
+    if (!confirm('Are you sure? This will delete the preview from the server.')) {
+        return;
+    }
+
+    // Extract preview filename from video source
+    const source = card.querySelector('video source');
+    if (source) {
+        const src = source.getAttribute('src');
+        const filename = src.split('/').pop();
+        try {
+            await fetch('/api/preview/' + encodeURIComponent(filename), {
+                method: 'DELETE'
+            });
+        } catch (e) {
+            // Continue with card removal even if delete fails
+        }
+    }
+
+    // Fade out and remove card
+    card.style.transition = 'opacity 0.3s';
+    card.style.opacity = '0';
+    card.style.pointerEvents = 'none';
+    setTimeout(() => {
+        card.remove();
+        if (document.querySelectorAll('.identify-card').length === 0) {
+            location.reload();
+        }
+    }, 300);
+}
+
 async function dismissAuditFlag(title, btn) {
     btn.disabled = true;
     btn.textContent = 'Dismissing...';

--- a/web/static/js/identify.js
+++ b/web/static/js/identify.js
@@ -183,29 +183,20 @@ async function handleRename(form, event) {
 
 async function dismissPreview(btn) {
     const card = btn.closest('.identify-card');
+    const stateFile = card.dataset.stateFile;
     const errorMsg = card.querySelector('.error-msg');
-    if (!confirm('Are you sure? This will delete the preview from the server.')) {
+    if (!confirm('Are you sure? This will dismiss the item and delete its preview from the server.')) {
         return;
     }
 
-    // Extract preview filename from video source
-    const source = card.querySelector('video source');
-    if (!source) {
-        errorMsg.textContent = 'No preview file to delete';
-        errorMsg.style.display = 'block';
-        return;
-    }
-
-    const src = source.getAttribute('src');
-    const filename = decodeURIComponent(src.split('/').pop());
     try {
-        const response = await fetch('/api/preview/' + encodeURIComponent(filename), {
-            method: 'DELETE'
+        const response = await fetch('/api/identify/' + encodeURIComponent(stateFile) + '/dismiss', {
+            method: 'POST'
         });
         const result = await response.json();
 
         if (!response.ok) {
-            errorMsg.textContent = 'Delete failed: ' + (result.error || 'Unknown error');
+            errorMsg.textContent = 'Dismiss failed: ' + (result.error || 'Unknown error');
             errorMsg.style.display = 'block';
             return;
         }

--- a/web/static/js/identify.js
+++ b/web/static/js/identify.js
@@ -11,7 +11,8 @@ function buildIdentifyCard(item) {
     const meta = item.metadata;
     const rawPreview = (meta.preview_path || '').trim();
     const previewFile = rawPreview ? rawPreview.split('/').pop() : '';
-    const displayTitle = (meta.title || '').replace(/_/g, ' ');
+    const displayTitle = (meta.title || '').replace(/_/g, ' ')
+        .replace(/\w\S*/g, w => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase());
     const yearDisplay = meta.year ? ' (' + meta.year + ')' : '';
 
     let previewHtml;

--- a/web/static/js/identify.js
+++ b/web/static/js/identify.js
@@ -41,7 +41,7 @@ function buildIdentifyCard(item) {
                 <div class="form-group">
                     <label for="title-${idx}">Movie Title</label>
                     <input type="text" id="title-${idx}" name="title"
-                           placeholder="The Matrix" required>
+                           value="${displayTitle}" required>
                 </div>
                 <div class="form-group">
                     <label for="year-${idx}">Year</label>

--- a/web/static/js/identify.js
+++ b/web/static/js/identify.js
@@ -9,7 +9,8 @@ function buildIdentifyCard(item) {
     cardCounter++;
     const idx = cardCounter;
     const meta = item.metadata;
-    const previewFile = meta.preview_path ? meta.preview_path.split('/').pop() : '';
+    const rawPreview = (meta.preview_path || '').trim();
+    const previewFile = rawPreview ? rawPreview.split('/').pop() : '';
     const displayTitle = (meta.title || '').replace(/_/g, ' ');
     const yearDisplay = meta.year ? ' (' + meta.year + ')' : '';
 

--- a/web/static/js/identify.js
+++ b/web/static/js/identify.js
@@ -1,7 +1,134 @@
 /**
  * Identify Page JavaScript
- * Handles renaming items and dismissing audit flags
+ * Handles renaming items, dismissing previews/audit flags, and auto-refresh.
  */
+
+let cardCounter = 0;
+
+function buildIdentifyCard(item) {
+    cardCounter++;
+    const idx = cardCounter;
+    const meta = item.metadata;
+    const previewFile = meta.preview_path ? meta.preview_path.split('/').pop() : '';
+    const displayTitle = (meta.title || '').replace(/_/g, ' ');
+    const yearDisplay = meta.year ? ' (' + meta.year + ')' : '';
+
+    let previewHtml;
+    if (previewFile) {
+        previewHtml = `
+            <video class="preview-video" controls preload="metadata">
+                <source src="/api/preview/${encodeURIComponent(previewFile)}" type="video/mp4">
+                Your browser does not support video playback.
+            </video>`;
+    } else {
+        previewHtml = `
+            <div class="no-preview">
+                No preview available<br>
+                <small>Preview will be generated during encoding</small>
+            </div>`;
+    }
+
+    return `
+    <div class="identify-card" data-state-file="${item.state_file}">
+        <button class="btn-dismiss-card" onclick="dismissPreview(this)" title="Dismiss">&times;</button>
+        <div class="success-msg"></div>
+        <div class="error-msg"></div>
+        <div class="preview-container">${previewHtml}</div>
+        <div class="current-name">Current: ${displayTitle}${yearDisplay}</div>
+        <form class="rename-form" onsubmit="return handleRename(this, event)">
+            <div class="form-row">
+                <div class="form-group">
+                    <label for="title-${idx}">Movie Title</label>
+                    <input type="text" id="title-${idx}" name="title"
+                           placeholder="The Matrix" required>
+                </div>
+                <div class="form-group">
+                    <label for="year-${idx}">Year</label>
+                    <input type="text" id="year-${idx}" name="year"
+                           placeholder="1999" pattern="[0-9]{4}" maxlength="4">
+                </div>
+            </div>
+            <button type="submit" class="btn btn-primary" style="width: 100%;">Rename &amp; Identify</button>
+        </form>
+        <div class="state-info">
+            <span class="status-badge state-${item.state}">${item.state}</span>
+            ${meta.nas_path ? '<span title="' + meta.nas_path + '">On NAS</span>' : ''}
+        </div>
+    </div>`;
+}
+
+function buildAuditCard(flag) {
+    const issues = flag.issues || [];
+    let issueHtml = '';
+    if (issues.includes('gibberish')) {
+        issueHtml += '<span class="audit-issue issue-gibberish">Suspicious Title</span>';
+    }
+    if (issues.includes('small')) {
+        issueHtml += `<span class="audit-issue issue-small">Small File (${flag.size_mb}MB)</span>`;
+    }
+    if (issues.includes('missing')) {
+        issueHtml += '<span class="audit-issue issue-missing">Missing Archive</span>';
+    }
+
+    const flaggedAt = flag.flagged_at ? flag.flagged_at.substring(0, 19) : 'Unknown';
+    const hostInfo = flag.hostname ? ' | Host: ' + flag.hostname : '';
+
+    return `
+    <div class="audit-card" data-title="${flag.title}">
+        <div class="audit-title">${flag.title}</div>
+        <div class="audit-issues">${issueHtml}</div>
+        <div class="audit-meta">Flagged: ${flaggedAt}${hostInfo}</div>
+        <button class="btn btn-dismiss" onclick="dismissAuditFlag('${flag.title}', this)">
+            Dismiss Flag
+        </button>
+    </div>`;
+}
+
+async function refreshIdentifyCards() {
+    try {
+        const [pendingRes, auditRes] = await Promise.all([
+            fetch('/api/identify/pending'),
+            fetch('/api/audit/flags')
+        ]);
+        const pending = await pendingRes.json();
+        const auditFlags = await auditRes.json();
+
+        // Rebuild identify section
+        const identifySection = document.getElementById('identify-section');
+        if (pending.length > 0) {
+            let html = '<h2 style="margin: 0 0 16px 0; color: #f59e0b;">Needs Identification</h2>';
+            html += '<p style="color: #666; margin-bottom: 16px;">These items have generic names. Watch the preview to identify each movie.</p>';
+            html += '<div class="identify-grid">';
+            pending.forEach(item => { html += buildIdentifyCard(item); });
+            html += '</div>';
+            identifySection.innerHTML = html;
+        } else if (auditFlags.length === 0) {
+            identifySection.innerHTML = `
+                <div class="empty-state">
+                    <h2>All Clear!</h2>
+                    <p>No issues found. All your DVDs have proper names and passed audit.</p>
+                    <p><a href="/">Return to Dashboard</a></p>
+                </div>`;
+        } else {
+            identifySection.innerHTML = '';
+        }
+
+        // Rebuild audit section
+        const auditSection = document.getElementById('audit-section');
+        if (auditFlags.length > 0) {
+            let html = '<div class="audit-section">';
+            html += '<h2>Audit Flags</h2>';
+            html += '<p class="subtitle">These videos were flagged by the hourly audit for potential issues.</p>';
+            auditFlags.forEach(flag => { html += buildAuditCard(flag); });
+            html += '</div>';
+            auditSection.innerHTML = html;
+        } else {
+            auditSection.innerHTML = '';
+        }
+    } catch (e) {
+        console.log('Refresh failed:', e);
+    }
+}
 
 async function handleRename(form, event) {
     event.preventDefault();
@@ -32,18 +159,12 @@ async function handleRename(form, event) {
         if (response.ok) {
             successMsg.textContent = 'Renamed successfully to: ' + title + (year ? ' (' + year + ')' : '');
             successMsg.style.display = 'block';
-            // Fade out and remove card after a moment
+            // Fade out then refresh from server
             setTimeout(() => {
                 card.style.opacity = '0.5';
                 card.style.pointerEvents = 'none';
             }, 1000);
-            setTimeout(() => {
-                card.remove();
-                // Check if no more cards
-                if (document.querySelectorAll('.identify-card').length === 0) {
-                    location.reload();
-                }
-            }, 2000);
+            setTimeout(() => refreshIdentifyCards(), 2000);
         } else {
             errorMsg.textContent = result.error || 'Rename failed';
             errorMsg.style.display = 'block';
@@ -75,7 +196,7 @@ async function dismissPreview(btn) {
     }
 
     const src = source.getAttribute('src');
-    const filename = src.split('/').pop();
+    const filename = decodeURIComponent(src.split('/').pop());
     try {
         const response = await fetch('/api/preview/' + encodeURIComponent(filename), {
             method: 'DELETE'
@@ -93,16 +214,11 @@ async function dismissPreview(btn) {
         return;
     }
 
-    // Fade out and remove card only on success
+    // Fade out then refresh from server
     card.style.transition = 'opacity 0.3s';
     card.style.opacity = '0';
     card.style.pointerEvents = 'none';
-    setTimeout(() => {
-        card.remove();
-        if (document.querySelectorAll('.identify-card').length === 0) {
-            location.reload();
-        }
-    }, 300);
+    setTimeout(() => refreshIdentifyCards(), 500);
 }
 
 async function dismissAuditFlag(title, btn) {
@@ -114,6 +230,7 @@ async function dismissAuditFlag(title, btn) {
         });
         if (response.ok) {
             btn.closest('.audit-card').remove();
+            refreshIdentifyCards();
         } else {
             const result = await response.json();
             alert('Failed: ' + (result.error || 'Unknown error'));
@@ -126,3 +243,7 @@ async function dismissAuditFlag(title, btn) {
         btn.textContent = 'Dismiss Flag';
     }
 }
+
+// Initial load and auto-refresh every 30 seconds
+refreshIdentifyCards();
+setInterval(refreshIdentifyCards, 30000);

--- a/web/templates/identify.html
+++ b/web/templates/identify.html
@@ -13,11 +13,30 @@
         gap: 20px;
     }
     .identify-card {
+        position: relative;
         background: white;
         border-radius: 8px;
         padding: 16px;
         box-shadow: 0 1px 3px rgba(0,0,0,0.1);
     }
+    .btn-dismiss-card {
+        position: absolute;
+        top: 8px;
+        right: 8px;
+        z-index: 10;
+        width: 28px;
+        height: 28px;
+        border-radius: 50%;
+        border: none;
+        background: #e5e7eb;
+        color: #374151;
+        font-size: 16px;
+        line-height: 28px;
+        text-align: center;
+        cursor: pointer;
+        padding: 0;
+    }
+    .btn-dismiss-card:hover { background: #d1d5db; }
     .preview-container {
         position: relative;
         background: #000;
@@ -168,6 +187,7 @@
 <div class="identify-grid">
     {% for item in pending %}
     <div class="identify-card" data-state-file="{{ item.state_file }}">
+        <button class="btn-dismiss-card" onclick="dismissPreview(this)" title="Dismiss">&times;</button>
         <div class="success-msg"></div>
         <div class="error-msg"></div>
 

--- a/web/templates/identify.html
+++ b/web/templates/identify.html
@@ -181,99 +181,10 @@
 {% block content %}
 <p class="subtitle">Items needing attention: generic names to identify, audit flags to review.</p>
 
-{% if pending %}
-<h2 style="margin: 0 0 16px 0; color: #f59e0b;">Needs Identification</h2>
-<p style="color: #666; margin-bottom: 16px;">These items have generic names. Watch the preview to identify each movie.</p>
-<div class="identify-grid">
-    {% for item in pending %}
-    <div class="identify-card" data-state-file="{{ item.state_file }}">
-        <button class="btn-dismiss-card" onclick="dismissPreview(this)" title="Dismiss">&times;</button>
-        <div class="success-msg"></div>
-        <div class="error-msg"></div>
+<div id="identify-section"></div>
 
-        <div class="preview-container">
-            {% if item.metadata.preview_path %}
-            <video class="preview-video" controls preload="metadata">
-                <source src="/api/preview/{{ item.metadata.preview_path.split('/')[-1] }}" type="video/mp4">
-                Your browser does not support video playback.
-            </video>
-            {% else %}
-            <div class="no-preview">
-                No preview available<br>
-                <small>Preview will be generated during encoding</small>
-            </div>
-            {% endif %}
-        </div>
-
-        <div class="current-name">
-            Current: {{ item.metadata.title | replace('_', ' ') }}
-            {% if item.metadata.year %} ({{ item.metadata.year }}){% endif %}
-        </div>
-
-        <form class="rename-form" onsubmit="return handleRename(this, event)">
-            <div class="form-row">
-                <div class="form-group">
-                    <label for="title-{{ loop.index }}">Movie Title</label>
-                    <input type="text" id="title-{{ loop.index }}" name="title"
-                           placeholder="The Matrix" required>
-                </div>
-                <div class="form-group">
-                    <label for="year-{{ loop.index }}">Year</label>
-                    <input type="text" id="year-{{ loop.index }}" name="year"
-                           placeholder="1999" pattern="[0-9]{4}" maxlength="4">
-                </div>
-            </div>
-            <button type="submit" class="btn btn-primary" style="width: 100%;">Rename &amp; Identify</button>
-        </form>
-
-        <div class="state-info">
-            <span class="status-badge state-{{ item.state }}">{{ item.state }}</span>
-            {% if item.metadata.nas_path %}
-            <span title="{{ item.metadata.nas_path }}">On NAS</span>
-            {% endif %}
-        </div>
-    </div>
-    {% endfor %}
-</div>
-{% else %}
-{% if not audit_flags %}
-<div class="empty-state">
-    <h2>All Clear!</h2>
-    <p>No issues found. All your DVDs have proper names and passed audit.</p>
-    <p><a href="/">Return to Dashboard</a></p>
-</div>
-{% endif %}
-{% endif %}
-
-{% if audit_flags %}
-<div class="audit-section">
-    <h2>Audit Flags</h2>
-    <p class="subtitle">These videos were flagged by the hourly audit for potential issues.</p>
-    {% for flag in audit_flags %}
-    <div class="audit-card" data-title="{{ flag.title }}">
-        <div class="audit-title">{{ flag.title }}</div>
-        <div class="audit-issues">
-            {% if 'gibberish' in flag.issues %}
-            <span class="audit-issue issue-gibberish">Suspicious Title</span>
-            {% endif %}
-            {% if 'small' in flag.issues %}
-            <span class="audit-issue issue-small">Small File ({{ flag.size_mb }}MB)</span>
-            {% endif %}
-            {% if 'missing' in flag.issues %}
-            <span class="audit-issue issue-missing">Missing Archive</span>
-            {% endif %}
-        </div>
-        <div class="audit-meta">
-            Flagged: {{ flag.flagged_at[:19] if flag.flagged_at else 'Unknown' }}
-            {% if flag.hostname %} | Host: {{ flag.hostname }}{% endif %}
-        </div>
-        <button class="btn btn-dismiss" onclick="dismissAuditFlag('{{ flag.title }}', this)">
-            Dismiss Flag
-        </button>
-    </div>
-    {% endfor %}
-</div>
-{% endif %}
+<div id="audit-section"></div>
+<p class="auto-refresh" style="font-size: 11px; color: #64748b; margin-top: 16px;">Auto-refreshes every 30 seconds</p>
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
## Summary

- Add [x] dismiss button to identify cards that deletes the preview file and clears the state file so cards don't reappear
- Convert identify page to dynamic rendering with 30-second auto-refresh from API
- Show all items with previews missing a year, not just generic titles
- Pre-fill title input with title-cased current name for quick year-only edits
- Fix NAS rename: read unmasked config, use dvd-web's own SSH key
- Fix preview serving with case-insensitive filename lookup
- Fix file permissions: encoder sets group-writable on previews, install script deploys dvd-web SSH key to NAS automatically

## Files changed

- `web/pages/api_identify.py` — DELETE preview, POST dismiss, case-insensitive preview lookup
- `web/static/js/identify.js` — Dynamic card rendering, auto-refresh, dismiss flow
- `web/templates/identify.html` — Replaced Jinja loops with JS-rendered containers
- `web/pages/dashboard.py` — Removed unused server-side data fetching
- `web/helpers/identifier.py` — Broadened filter, unmasked NAS config, SSH identity support
- `scripts/dvd-encoder.sh` — Group-writable preview permissions
- `remote-install.sh` — Auto-deploy dvd-web SSH key to NAS during install

## Test plan

- [ ] Load `/identify` — all items with previews and missing years appear
- [ ] Click [x] dismiss — confirm dialog, card removed, preview deleted on server
- [ ] Cards auto-refresh every 30 seconds
- [ ] Rename with year only (title pre-filled) — NAS file renamed via SSH
- [ ] Run `remote-install.sh` on fresh server — dvd-web SSH key deployed to NAS

🤖 Generated with [Claude Code](https://claude.com/claude-code)